### PR TITLE
Fixing pandoc issue with relative path refs

### DIFF
--- a/.github/workflows/reusable-pdf-generator.yaml
+++ b/.github/workflows/reusable-pdf-generator.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir -p output
           cur=$(pwd)
-          cd meetings
+          cd ${{ inputs.folder }}
           for file in *.md; do
             filename=$(basename "$file" .md)
             echo "Converting $file to output/$filename.pdf"

--- a/.github/workflows/reusable-pdf-generator.yaml
+++ b/.github/workflows/reusable-pdf-generator.yaml
@@ -41,11 +41,14 @@ jobs:
       - name: Convert Markdown to PDF
         run: |
           mkdir -p output
-          for file in ${{ inputs.folder }}/*.md; do
+          cur=$(pwd)
+          cd meetings
+          for file in *.md; do
             filename=$(basename "$file" .md)
             echo "Converting $file to output/$filename.pdf"
-            pandoc "$file" -o "output/$filename.pdf"
+            pandoc "$file" -o "$cur/output/$filename.pdf"
           done
+          cd "$cur"
 
       - name: Check if pdf-branch exists
         id: check-branch


### PR DESCRIPTION
The previous solution had issues with local references to, e.g., pictures in a subfolder. pandoc resolves the references from the path it is executed in, not the path that the source file is in. This is fixed with this change. It should behave without a recognizable change outside of the workflow step.